### PR TITLE
chore: Update the gcp tf provider

### DIFF
--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.40"
+      version = "~> 7.16"
     }
   }
 }


### PR DESCRIPTION
Updating this manually as dependabot has not kicked in yet and this is
required to update the deployment.
